### PR TITLE
[Travis] Adding support for forks testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ before_install:
     - go get github.com/mitchellh/gox
 
 install:
-    - $GOPATH/bin/dep ensure
+    # Making sure to dep ensure with the current repository URL to avoid any packages issues
+    # if the build is triggered from a fork.
+    # dep will also make sure to get the branch from which the commit originates.
+    - if [ $TRAVIS_REPO_SLUG == "prebid/prebid-server" ]; then dep ensure; else eval "dep ensure -add github.com/prebid/prebid-server:github.com/$TRAVIS_REPO_SLUG@$TRAVIS_BRANCH"; fi
 
 script:
     - "./validate.sh --nofmt --cov --race 10"


### PR DESCRIPTION
This CL allows to add testing support in Travis for forks leveraging
the `dep ensure --add` option to support this use case.

As of today, `dep ensure` will pull the official prebid-server repo and
compile it but won't rely on the forked repo.

This change needs to stay in the fork to ensure Travis multi-package builds work.